### PR TITLE
Fix badges and TODOs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,3 @@ I feel that the makeTransactionFromArgs() method should be part of the program,
 somehow replacing aspects of the TransactionMaker class - but I'm worried a chance here will require
 many changes throughout the program.
  Transaction + Balance --> ReportLine
- 
-TODO:
-1. The original README.md was deleted from this branch. Are there other files missing?
-1. FlipTableTest: I want main to be able to use the FlipTable, but I am unsuccessful with using the .fromIterable method, 
-so instead I want to use FlipTableConverters.fromObjects. While I have a header, the second argument needs to be of 
-String[][] type. This suggests I need to update the Budget.report() method - so that the steam converts this to nested arrays.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-[![Build Status](https://travis-ci.org/perrymant/moneymaker.svg?branch=sprint-2)](https://travis-ci.org/perrymant/moneymaker) 
-![GitHub](https://img.shields.io/github/license/mashape/apistatus.svg) 
-![GitHub package version](https://img.shields.io/github/package-json/v/badges/shields.svg)
-
+[![Build Status](https://travis-ci.org/perrymant/moneymaker.svg)](https://travis-ci.org/perrymant/moneymaker)
+![GitHub](https://img.shields.io/github/license/perrymant/moneymaker.svg)
 
 budget calculator
 1. user input (hardcoded)


### PR DESCRIPTION
Noticed the badges were a bit off:
- Shouldn't specify the branch in the build status, this should basically always be `master`. If Travis does something special when there are no branches mentioned then that's a bonus, but since what we really look at is the pass/fail of each individual commit this isn't really that important. What's 'important' is getting a feel for the quality of the project when glancing at the README when first visiting the repo in GitHub.
- The license badge now identifies the license of this project. This was previously reflecting [mashape/apistatus](https://github.com/mashape/apistatus)'s license.
- This project has no package version, as it is not officially released anywhere. The process of actually doing so for Java projects is annoying, although [I have managed to do so in the past](https://github.com/kinbiko/bugsnag-maven-plugin).

Also removed the TODOs that were addressed in our session. I believe you've removed these on your computer as well - if you've committed these changes already this should serve as a fun little exercise in solving merge conflicts. 🙈 🙉 🙊 